### PR TITLE
fix: Fixing API Build

### DIFF
--- a/packages/api/tsconfig.build.json
+++ b/packages/api/tsconfig.build.json
@@ -1,4 +1,4 @@
 {
   "extends": "./tsconfig.json",
-  "exclude": ["node_modules", "test", "dist", "**/*spec.ts"]
+  "exclude": ["node_modules", "test", "dist", "**/*spec.ts", "vitest.config.ts"]
 }


### PR DESCRIPTION
- vitest.config.ts was being included in final API build, which caused the dir structure to change and prod deployment to fail